### PR TITLE
Add log monitoring agent and web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# tofe_ai
+# Monitoring Prototype
+
+This repository contains two entry points for a monitoring prototype:
+
+* `monitoring_agent.py` – scans application log files for errors and pushes
+  events to Elasticsearch. When an incident is detected the agent sends
+  notifications, schedules a Teams meeting, and prepares a PDF summary.
+* `web_app.py` – a minimal Flask web application that exposes a `/logs`
+  endpoint for listing stored events from Elasticsearch.
+
+All external integrations (Elasticsearch, Twilio, SMTP, Microsoft Graph, PDF
+creation) are represented as placeholders. Provide valid credentials through
+environment variables when running the scripts in a real environment.
+
+## Usage
+
+```bash
+# Run the monitoring agent
+python monitoring_agent.py
+
+# Start the web interface
+python web_app.py
+```
+
+Both scripts expect an Elasticsearch instance at `ELASTIC_HOST` (defaults to
+`http://localhost:9200`).

--- a/monitoring_agent.py
+++ b/monitoring_agent.py
@@ -1,0 +1,142 @@
+"""Monitoring agent for operations department.
+
+This script tails application log files, stores important events in
+Elasticsearch, notifies engineers through WhatsApp and email, schedules a
+Teams meeting for incident response, and generates a PDF summary once the
+meeting concludes.
+
+The module is intentionally light on real integrations; production use will
+require wiring in API credentials and additional infrastructure such as a
+Celery worker or message queue.  It is designed to run alongside an Elastic
+Stack deployment."""
+
+import os
+from datetime import datetime
+from typing import Iterable, List
+
+# Placeholder imports for external services
+try:
+    from elasticsearch import Elasticsearch  # type: ignore
+    from twilio.rest import Client as TwilioClient  # type: ignore
+    import smtplib
+    import requests
+    from fpdf import FPDF  # type: ignore
+except ImportError:
+    Elasticsearch = TwilioClient = smtplib = requests = FPDF = None  # noqa: N806
+
+
+class MonitoringAgent:
+    """Simple file based log monitoring agent."""
+
+    def __init__(self, log_paths: Iterable[str]):
+        self.log_paths = list(log_paths)
+        self.elastic_host = os.getenv("ELASTIC_HOST", "http://localhost:9200")
+        self.twilio_sid = os.getenv("TWILIO_SID")
+        self.twilio_token = os.getenv("TWILIO_TOKEN")
+        self.twilio_whatsapp = os.getenv("TWILIO_WHATSAPP_NUMBER")
+        self.email_from = os.getenv("EMAIL_FROM")
+        self.email_password = os.getenv("EMAIL_PASSWORD")
+
+        if Elasticsearch:
+            self.es = Elasticsearch(self.elastic_host)
+        else:
+            self.es = None
+
+    def scan_logs(self) -> List[str]:
+        """Return log lines that contain the word 'ERROR'."""
+        events: List[str] = []
+        for path in self.log_paths:
+            if not os.path.exists(path):
+                continue
+            try:
+                with open(path, "r", encoding="utf-8") as handle:
+                    for line in handle.readlines():
+                        if "ERROR" in line:
+                            events.append(f"{path}: {line.strip()}")
+            except OSError:
+                continue
+        return events
+
+    def log_to_elastic(self, message: str) -> None:
+        """Log events to Elasticsearch."""
+        if not self.es:
+            print("Elasticsearch client not configured")
+            return
+        self.es.index(
+            index="monitoring",
+            document={
+                "timestamp": datetime.utcnow().isoformat(),
+                "message": message,
+            },
+        )
+
+    def notify_whatsapp(self, message: str) -> None:
+        """Send WhatsApp notification."""
+        if not TwilioClient or not self.twilio_sid or not self.twilio_token:
+            print("Twilio not configured")
+            return
+        client = TwilioClient(self.twilio_sid, self.twilio_token)
+        client.messages.create(
+            body=message,
+            from_=f"whatsapp:{self.twilio_whatsapp}",
+            to=f"whatsapp:{os.getenv('WHATSAPP_TO')}"
+        )
+
+    def notify_email(self, subject: str, body: str) -> None:
+        """Send email notification."""
+        if not smtplib or not self.email_from or not self.email_password:
+            print("SMTP not configured")
+            return
+        with smtplib.SMTP("smtp.gmail.com", 587) as smtp:
+            smtp.starttls()
+            smtp.login(self.email_from, self.email_password)
+            msg = f"Subject: {subject}\n\n{body}"
+            smtp.sendmail(self.email_from, os.getenv("EMAIL_TO"), msg)
+
+    def schedule_teams_meeting(self, subject: str) -> None:
+        """Schedule a Microsoft Teams meeting using Microsoft Graph API."""
+        if not requests:
+            print("Requests not available")
+            return
+        token = os.getenv("GRAPH_TOKEN")
+        if not token:
+            print("Graph token not configured")
+            return
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        data = {
+            "subject": subject,
+            "startDateTime": datetime.utcnow().isoformat(),
+            "endDateTime": (datetime.utcnow()).isoformat(),
+        }
+        requests.post("https://graph.microsoft.com/v1.0/me/onlineMeetings", headers=headers, json=data)
+
+    def generate_pdf_report(self, message: str, filename: str) -> str:
+        """Generate a simple PDF report."""
+        if not FPDF:
+            print("FPDF not installed")
+            return ""
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.multi_cell(0, 10, message)
+        pdf.output(filename)
+        return filename
+
+    def run(self) -> None:
+        events = self.scan_logs()
+        if not events:
+            return
+        message = "\n".join(events)
+        self.log_to_elastic(message)
+        self.notify_whatsapp(message)
+        self.notify_email("Log Alert", message)
+        self.schedule_teams_meeting("Incident Response")
+        report_path = self.generate_pdf_report(message, "incident_report.pdf")
+        if report_path:
+            # Real implementation would distribute the report and meeting recording
+            pass
+
+
+if __name__ == "__main__":
+    agent = MonitoringAgent(log_paths=["/var/log/syslog"])
+    agent.run()

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,34 @@
+"""Minimal Flask web application for viewing log events.
+
+The application expects an Elasticsearch instance and exposes a single
+endpoint for listing collected monitoring events.
+"""
+
+import os
+from flask import Flask, jsonify
+
+try:
+    from elasticsearch import Elasticsearch  # type: ignore
+except ImportError:  # pragma: no cover
+    Elasticsearch = None  # type: ignore
+
+app = Flask(__name__)
+
+if Elasticsearch:
+    es = Elasticsearch(os.getenv("ELASTIC_HOST", "http://localhost:9200"))
+else:  # pragma: no cover
+    es = None
+
+
+@app.get("/logs")
+def list_logs():
+    """Return log documents stored in Elasticsearch."""
+    if not es:
+        return jsonify({"error": "Elasticsearch client not configured"}), 500
+    resp = es.search(index="monitoring", query={"match_all": {}})
+    hits = [hit.get("_source", {}) for hit in resp.get("hits", {}).get("hits", [])]
+    return jsonify(hits)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- refine monitoring script into a log-based agent that logs incidents to Elasticsearch, sends notifications, schedules Teams meetings, and writes PDF summaries
- introduce a minimal Flask web application to view monitoring logs
- document usage and ignore local environment files

## Testing
- `python -m py_compile monitoring_agent.py web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b6b359b94832d84bdaf02866979f5