### PR TITLE
Add placeholder FastAPI AI ops console web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository contains two entry points for a monitoring prototype:
   notifications, schedules a Teams meeting, and prepares a PDF summary.
 * `web_app.py` – a minimal Flask web application that exposes a `/logs`
   endpoint for listing stored events from Elasticsearch.
+* `ops_console.py` – a FastAPI operations console providing placeholder
+  endpoints for incidents, runbooks and a RAG powered chatbot.
 
 All external integrations (Elasticsearch, Twilio, SMTP, Microsoft Graph, PDF
 creation) are represented as placeholders. Provide valid credentials through
@@ -20,7 +22,10 @@ python monitoring_agent.py
 
 # Start the web interface
 python web_app.py
+
+# Run the AI operations console
+uvicorn ops_console:app --reload
 ```
 
-Both scripts expect an Elasticsearch instance at `ELASTIC_HOST` (defaults to
+All scripts expect an Elasticsearch instance at `ELASTIC_HOST` (defaults to
 `http://localhost:9200`).

--- a/ops_console.py
+++ b/ops_console.py
@@ -1,0 +1,73 @@
+"""AI-powered operations console web application.
+
+This FastAPI app exposes a few endpoints that mimic features of a fully
+fledged AI operations platform:
+
+* ``/logs`` – list log events from Elasticsearch.
+* ``/incidents`` – return incident clusters from Elasticsearch.
+* ``/runbooks/{name}`` – stub endpoint that would trigger runbook automation.
+* ``/chat`` – simple retrieval endpoint representing a RAG chatbot.
+
+The implementation is intentionally lightweight and uses placeholders for
+external systems. It is designed for demonstration purposes only.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, HTTPException
+
+try:  # pragma: no cover - optional dependency
+    from elasticsearch import Elasticsearch  # type: ignore
+except ImportError:  # pragma: no cover
+    Elasticsearch = None  # type: ignore
+
+app = FastAPI(title="AI Ops Console")
+
+if Elasticsearch:
+    es = Elasticsearch(os.getenv("ELASTIC_HOST", "http://localhost:9200"))
+else:  # pragma: no cover
+    es = None
+
+
+@app.get("/logs")
+def list_logs() -> List[Dict[str, Any]]:
+    """Return log documents stored in Elasticsearch."""
+    if not es:
+        raise HTTPException(status_code=500, detail="Elasticsearch client not configured")
+    resp = es.search(index="monitoring", query={"match_all": {}})
+    hits = [hit.get("_source", {}) for hit in resp.get("hits", {}).get("hits", [])]
+    return hits
+
+
+@app.get("/incidents")
+def list_incidents() -> List[Dict[str, Any]]:
+    """Return incident clusters from Elasticsearch."""
+    if not es:
+        raise HTTPException(status_code=500, detail="Elasticsearch client not configured")
+    resp = es.search(index="incidents", query={"match_all": {}})
+    hits = [hit.get("_source", {}) for hit in resp.get("hits", {}).get("hits", [])]
+    return hits
+
+
+@app.post("/runbooks/{name}")
+def run_runbook(name: str) -> Dict[str, str]:
+    """Stub endpoint that pretends to run a named runbook."""
+    # Real implementations would trigger automation workflows or external systems.
+    return {"runbook": name, "status": "scheduled"}
+
+
+@app.post("/chat")
+def chat(query: str) -> Dict[str, str]:
+    """Placeholder RAG chatbot endpoint."""
+    # In production this would query a vector index and synthesize an answer.
+    answer = f"Stub answer for: {query}"
+    return {"answer": answer}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add `ops_console.py` FastAPI app exposing logs, incidents, runbooks, and chat endpoints
- document running the new operations console in README

## Testing
- `python -m py_compile monitoring_agent.py monitoring_system.py web_app.py ops_console.py`


------
https://chatgpt.com/codex/tasks/task_e_689e5f83ae38832db81a277424722a37